### PR TITLE
Handle GA POSTs sending data as query string

### DIFF
--- a/app/js/analyzer.js
+++ b/app/js/analyzer.js
@@ -6,14 +6,11 @@ function pick(searchParams, keys) {
 }
 
 function getSearchParams(request) {
-  if (request.method === "GET") {
-    return new URL(request.url).searchParams;
-  }
   if (request.postData && request.postData.text) {
     return new URLSearchParams(request.postData.text);
   }
 
-  return new URLSearchParams();
+  return new URL(request.url).searchParams;
 }
 
 class Analyzer {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Linda",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "manifest_version": 2,
   "description": "Linda is watching!",
   "devtools_page": "devtools.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linda",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "description": "Linda is watching!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
GA page views use the POST method but with no body.
The parameters are sent in the query string instead.