### PR TITLE
fix/backround scripts

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -1,5 +1,3 @@
-
-
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === "devtools-page") {
     chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -5,9 +5,7 @@
   "description": "Linda is watching!",
   "devtools_page": "devtools.html",
   "background": {
-    "serviceWorker": [
-      "js/background.js"
-    ]
+    "service_worker": "js/background.js"
   },
   "host_permissions": [
     "*://*/*"


### PR DESCRIPTION
The migration to Manifest version 3 did not follow the specification,
and disabled the background script and the automatic clearing when
reloading the page.